### PR TITLE
Remove extraneous pseudo entries from NAMESPACE

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -65,8 +65,6 @@ export(
   "read.MFCLPseudo",
   "read.MFCLPseudoAlt",
   "read.MFCLPseudoCatchEffort",
-  "read.MFCLPseudoCatch",
-  "read.MFCLPseudoEffort",
   "read.MFCLPseudoSizeComp",
   "read.MFCLRec",
   "read.MFCLRegion",


### PR DESCRIPTION
Hi!

I've had good success installing FLR4MFCL in the past, but I was not able to install FLR4MFCL today, neither using install_github nor installing locally.

The error message is:
```
Error: package or namespace load failed for 'FLR4MFCL' in namespaceExport(ns, exports):
 undefined exports: read.MFCLPseudoCatch, read.MFCLPseudoEffort
```

Sure enough, the NAMESPACE file was trying to export some functions that do not exist (anymore). I removed the two entries `read.MFCLPseudoCatch` and `read.MFCLPseudoEffort` from the NAMESPACE file and the package now installs like a charm.