### PR TITLE
Fix installation warning and R CMD check errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: R functions for taming MULTIFAN-CL
 Version: 1.3.24
 Author: Robert Scott 
 Description: Everything you ever dreamed of. R4MFCL but with S4 classes and FLR compatability
-Depends: lattice, FLCore
+Depends: R (>= 3.5.0), lattice, FLCore
 Imports: methods
 Maintainer: Robert Scott <robertsc@spc.int>
 License: GPL-3

--- a/R/FLQuantMethods.r
+++ b/R/FLQuantMethods.r
@@ -1,10 +1,6 @@
 #FLR4MFCL - R4MFCL built with FLR classes
 #Copyright (C) 2018  Rob Scott
 
-
-
-
-
 ## #' @rdname FLQuant
 ## #' @aliases FLQuant,MFCLLenFreq-method
 
@@ -75,13 +71,13 @@ setMethod("FLQuant", signature(object="MFCLLenFreq2"),
 #'
 #' Returns a quarterly time series from a seasonally structured FLQuant.
 #'
-#' @param quant:  An FLQuant object 
-#' 
+#' @param quant An FLQuant object.
 #'
-#' @return An object of class FLQuant
+#' @return An object of class FLQuant.
 #'
 #' @examples
-#' flq(stock.n(ple4))
+#' data(ple4)
+#' qts(stock.n(ple4))
 #'
 #' @export
 
@@ -155,7 +151,3 @@ ats <- function(quant){
   return(as.FLQuant(qdf[,c(1:7)]))
   
 }
-
-
-
-

--- a/R/flagTools.r
+++ b/R/flagTools.r
@@ -1,15 +1,16 @@
 #FLR4MFCL - R4MFCL built with FLR classes
 #Copyright (C) 2018  Rob Scott
 
-#' recruitment peiods
+#' recruitment periods
 #'
 #' Calculates recruitment periods for deterministic and stochastic projection settings
 #'
-#' @param parfile A object of class MFCLPar 
+#' @param parfile An object of class MFCLPar
 #'
 #' @return An object of class numeric vector
 #'
 #' @examples
+#' data(par)
 #' recPeriod(par)
 #'
 #' @export
@@ -62,12 +63,13 @@ recPeriod <- function(par, af199=NULL, af200=NULL, pf232=NULL, pf233=NULL, show=
 #'
 #' flag settings summarised by MFCL User Guide sections
 #'
-#' @param par A object of class MFCLPar 
+#' @param par An object of class MFCLPar
 #' @param type A character string specifying the MFCL User Guide section
 #'
 #' @return A data frame of flag settings
 #'
 #' @examples
+#' data(par)
 #' flagSummary(par, 'projection')
 #'
 #' @export
@@ -93,13 +95,16 @@ flagSummary <- function(par, type){
 #'
 #' flag differences between two par files
 #'
-#' @param par A object of class MFCLPar 
-#' @param par A object of class MFCLPar 
+#' @param par An object of class MFCLPar
+#' @param par An object of class MFCLPar
 #'
 #' @return A data frame of flag settings for par1 and par2
 #'
 #' @examples
-#' flagDiff(par, par)
+#' data(par)
+#' par1 <- par2 <- par
+#' flags(par2)[20,"value"] <- 12
+#' flagDiff(par1, par2)
 #'
 #' @export
 
@@ -111,8 +116,3 @@ flagDiff <- function(par1, par2){
   
   return(res)
 }
-
-
-
-
-

--- a/R/genericMethods.r
+++ b/R/genericMethods.r
@@ -23,7 +23,9 @@
 #' @rdname write-methods
 #'
 #' @examples
-#' write(MFCLFrqStats())
+#'\dontrun{
+#' write(MFCLFrqStats(), "file.txt")
+#' }
 
 setGeneric('write', function(x, file, append=F, ...) standardGeneric('write')) 
 
@@ -329,18 +331,3 @@ checkUnitDimnames <- function(obj,nfisheries){
       }
       return(obj)
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/R/genericMethods.r
+++ b/R/genericMethods.r
@@ -299,25 +299,23 @@ setMethod('modifyRRini', signature(ini='MFCLIni',tag='MFCLTag',rr='data.frame',P
 
 #' checkUnitDimnames
 #'
-#' Re-orders the unit dimnames in ascending order instead 
+#' Re-orders the unit dimnames in ascending order instead
 #' of default ordering of FLQuant method which uses the year dimension
 #'
 #' @param obj An object of class MFCL eg. MFCLFrq, MFCLPar, etc.
 #' @param nfisheries The number of fisheries in the model
 #'
-#' @param ... Additional argument list that might not ever
-#'  be used.
+#' @param ... Additional argument list that might not ever be used.
 #'
 #' @return Returns an object of the same class but with FLQuant unit dimension
 #' re-ordered as appropriate.
-#' 
-#' 
 #'
 #' @examples
+#' \dontrun{
 #' checkUnitDimnames(MFCLRep())
+#' }
 
-
-checkUnitDimnames <-    function(obj,nfisheries){
+checkUnitDimnames <- function(obj,nfisheries){
       unit_order <- as.character(1:nfisheries)
       # ID FLQs with unit dimensions
       repslots <- getSlots(class(obj))

--- a/R/hcrs.R
+++ b/R/hcrs.R
@@ -196,20 +196,20 @@ hcr_asymptotic_constrained <- function(sbsbf0, params, reference_out){
 #'
 #' @rdname hcr_funcs
 #' @examples
+#' # Without constraint
+#' msectrl <- MFCLMSEControl()
+#' hcr(msectrl) <- "hcr_threshold"
+#' hcr_params(msectrl) <- c(sbsbf0_min=0.1, sbsbf0_max=0.5, out_min=0.0, out_max=1.2)
+#' eval_hcr(msectrl, sbsbf0=0.3) # 0.5
 #'
-#' Without constraint
-#'msectrl <- MFCLMSEControl()
-#'hcr(msectrl) <- "hcr_threshold"
-#'hcr_params(msectrl) <- c(sbsbf0_min=0.1, sbsbf0_max=0.5, out_min=0.0, out_max=1.2)
-#'eval_hcr(msectrl, sbsbf0=0.3) # 0.5
-#'
-#' With a constraint of 15% each way
-#'msectrl2 <- MFCLMSEControl()
-#'hcr(msectrl2) <- "hcr_threshold_constrained"
-#'hcr_params(msectrl2) <- c(sbsbf0_min=0.1, sbsbf0_max=0.5, out_min=0.0, out_max=1.2, max_change_up=1.15, max_change_down=0.85)
-#'eval_hcr(msectrl2, sbsbf0=0.3, reference_out=1.0)
-#'# So that next out cannot change by more 15%
-#'eval_hcr(msectrl2, sbsbf0=0.3, reference_out=0.1)
+#' # With a constraint of 15% each way
+#' msectrl2 <- MFCLMSEControl()
+#' hcr(msectrl2) <- "hcr_threshold_constrained"
+#' hcr_params(msectrl2) <- c(sbsbf0_min=0.1, sbsbf0_max=0.5, out_min=0.0, out_max=1.2, max_change_up=1.15, max_change_down=0.85)
+#' eval_hcr(msectrl2, sbsbf0=0.3, reference_out=1.0)
+#' # So that next out cannot change by more 15%
+#' eval_hcr(msectrl2, sbsbf0=0.3, reference_out=0.1)
+
 hcr_threshold_constrained <- function(sbsbf0, params, reference_out){
   out <- hcr_constrained(sbsbf0=sbsbf0, params=params, reference_out=reference_out, hcr_func="hcr_threshold")
   return(out)

--- a/R/mfcl.r
+++ b/R/mfcl.r
@@ -2,14 +2,12 @@
 #'
 #' Runs MFCL with defined inputs
 #'
-#' @param frq:    An object of class MFCLFrq.
-#' @param par:    An object of class MFCLPar.
-#' @param outpar: The name of the output par file
-#' @param switch: Optional numeric vector of additional flag settings
-#' @param spp:    character string with 3 letter species code - optional but required to produce the .cfg file if missing
-#'
-#' @param ... Additional argument list that might not ever
-#'  be used.
+#' @param frq An object of class MFCLFrq.
+#' @param par An object of class MFCLPar.
+#' @param outpar The name of the output par file.
+#' @param switch Optional numeric vector of additional flag settings.
+#' @param spp Character string with 3 letter species code - optional but required to produce the .cfg file if missing.
+#' @param ... Additional argument list that might not ever be used.
 #'
 #' @return Creates a text file at the specified location.
 #' 
@@ -18,10 +16,6 @@
 #' @export
 #' @docType methods
 #' @rdname mfcl-methods
-#'
-#' @examples
-#' write(MFCLFrqStats())
-
 
 check.mfcl.cfg <- function(dir=".", spp){
   
@@ -39,7 +33,6 @@ check.mfcl.cfg <- function(dir=".", spp){
     
     cat(cfg, file=paste(dir,"mfcl.cfg",sep="/"))
   }
-  
 }
 
 

--- a/R/mfcl.r
+++ b/R/mfcl.r
@@ -207,14 +207,15 @@ getMFCLversion <- function(){
 #'
 #' Returns a data.frame of parameters and their gradients in reverse order
 #'
-#' @param grads:  text string of input file name for sorted gradients
-#' @param parnames:  text string of input file name for parameter names
-#' 
+#' @param grads text string of input file name for sorted gradients
+#' @param parnames text string of input file name for parameter names
 #'
 #' @return data.frame of parameter gradients
 #'
 #' @examples
+#' \dontrun{
 #' gradients()
+#' }
 #'
 #' @export
 
@@ -236,6 +237,3 @@ gradients <- function(grads="sorted_gradient.rpt", parnames="xinit.rpt"){
   
   return(df3[rev(order(df3$gradient)),])
 }
-
-
-

--- a/R/mohns_rho.r
+++ b/R/mohns_rho.r
@@ -5,11 +5,11 @@
 #'
 #' Calculate mohns rho for retrospective analyses
 #'
-#' @param obj:    An object of class list containing the rep files from the final assessment and each retrospective peel. 
+#' @param obj An object of class list containing the rep files from the final assessment and each retrospective peel.
 #'
-#' @param depletion_method: the method for calculating depletion (default SBSBF0)
+#' @param depletion_method The method for calculating depletion (default SBSBF0).
 #'
-#' @return A numerric value of mohn's rho
+#' @return A numeric value of mohn's rho.
 #' 
 #' @seealso \code{\link{SBSBF0}} and \code{\link{MFCLRep}}
 #' 
@@ -18,16 +18,14 @@
 #' @rdname mfcl-methods
 #'
 #' @examples
+#' \dontrun{
 #' mohns_rho(retros)
-
-
+#' }
 
 setGeneric('mohns_rho', function(object, ...) standardGeneric('mohns_rho')) 
 
 #' @rdname mfcl-methods
 #' @aliases mfcl
-
-
 
 setMethod("mohns_rho", signature(object="list"), function(object, depletion_method='SBSBF0', ...){
   
@@ -61,5 +59,3 @@ setMethod("mohns_rho", signature(object="list"), function(object, depletion_meth
 #xyplot(data~year, group=qname, data=FLQuants(mcf(lapply(rep_retro_list, SBSBF0))), type="l", ylim=c(0,1), panel=pfunretro)
 
 #mohns_rho(rep_retro_list[-1], 'SBSBF0')
-
-

--- a/R/plot.r
+++ b/R/plot.r
@@ -15,7 +15,9 @@
 #' @rdname mfcl-methods
 #'
 #' @examples
+#' \dontrun{
 #' plot(MFCLFrq())
+#' }
 #'
 #' @aliases mfcl
 

--- a/R/read.MFCLCatch.r
+++ b/R/read.MFCLCatch.r
@@ -13,7 +13,7 @@
 #' @return An object of class MFCLCatch
 #'
 #' @examples
-#' read.MFCLCatch("C://R4MFCL//test_data//skj_ref_case//catch.rep", dimensions(par))
+#' read.MFCLCatch("C:/R4MFCL/test_data/skj_ref_case/catch.rep", dimensions(par))
 #' read.MFCLCatch("/home/robertsc/skj/HCR/run0/catch.rep", dimensions(par))
 #'
 #' @export

--- a/R/read.MFCLCatch.r
+++ b/R/read.MFCLCatch.r
@@ -13,8 +13,10 @@
 #' @return An object of class MFCLCatch
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLCatch("C:/R4MFCL/test_data/skj_ref_case/catch.rep", dimensions(par))
 #' read.MFCLCatch("/home/robertsc/skj/HCR/run0/catch.rep", dimensions(par))
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLFrq.r
+++ b/R/read.MFCLFrq.r
@@ -87,7 +87,9 @@ read.MFCLFrqStats <- function(frqfile){
 #' @return An object of class MFCLLenFreq
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLLenFreq("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLFrq.r
+++ b/R/read.MFCLFrq.r
@@ -398,7 +398,9 @@ read.MFCLLenFreq2 <- function(frqfile){
 #' @return An object of class MFCLFrq
 #'
 #' @examples
-#' read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
+#' \dontrun{
+#' read.MFCLFrq2(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLFrq.r
+++ b/R/read.MFCLFrq.r
@@ -260,7 +260,9 @@ read.MFCLFrq <- function(frqfile){
 #' @return An object of class MFCLLenFreq
 #'
 #' @examples
-#' read.MFCLLenFreq("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
+#' \dontrun{
+#' read.MFCLLenFreq2("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLFrq.r
+++ b/R/read.MFCLFrq.r
@@ -1,7 +1,6 @@
 #FLR4MFCL - R4MFCL built with FLR classes
 #Copyright (C) 2018  Rob Scott
 
-
 #' MFCL Frq Statistics
 #'
 #' Extracts the essential ranges and dimensions from the frq file
@@ -16,7 +15,6 @@
 #' }
 #'
 #' @export
-
 
 read.MFCLFrqStats <- function(frqfile){
   
@@ -201,12 +199,6 @@ read.MFCLLenFreq <- function(frqfile){
 }
 
 
-
-
-
-
-
-
 #' MFCL frq file reader
 #'
 #' Reads the entire contents of the frq file
@@ -245,10 +237,6 @@ read.MFCLFrq <- function(frqfile){
   return(res)
     
 }
-
-
-
-
 
 
 #' MFCL Length Frequency2 - MUFDAGR friendly
@@ -388,7 +376,6 @@ read.MFCLLenFreq2 <- function(frqfile){
 }
 
 
-
 #' MFCL frq2 file reader - Mufdagr friendly
 #'
 #' Reads the entire contents of the frq file
@@ -432,4 +419,3 @@ read.MFCLFrq2 <- function(frqfile){
 }
 
 #frqfile <- 'C:/R4MFCL/test_data/skj_ref_case/skj.frq'
-

--- a/R/read.MFCLFrq.r
+++ b/R/read.MFCLFrq.r
@@ -11,7 +11,7 @@
 #' @return An object of class MFCLFrqStats
 #'
 #' @examples
-#' read.MFCLFrqStats("C://R4MFCL//test_data//skj_ref_case//skj.frq")
+#' read.MFCLFrqStats("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
 #'
 #' @export
 
@@ -85,7 +85,7 @@ read.MFCLFrqStats <- function(frqfile){
 #' @return An object of class MFCLLenFreq
 #'
 #' @examples
-#' read.MFCLLenFreq("C://R4MFCL//test_data//skj_ref_case//skj.frq")
+#' read.MFCLLenFreq("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
 #'
 #' @export
 
@@ -212,7 +212,7 @@ read.MFCLLenFreq <- function(frqfile){
 #' @return An object of class MFCLFrq
 #'
 #' @examples
-#' read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='//'))
+#' read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
 #'
 #' @export
 
@@ -254,7 +254,7 @@ read.MFCLFrq <- function(frqfile){
 #' @return An object of class MFCLLenFreq
 #'
 #' @examples
-#' read.MFCLLenFreq("C://R4MFCL//test_data//skj_ref_case//skj.frq")
+#' read.MFCLLenFreq("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
 #'
 #' @export
 
@@ -390,7 +390,7 @@ read.MFCLLenFreq2 <- function(frqfile){
 #' @return An object of class MFCLFrq
 #'
 #' @examples
-#' read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='//'))
+#' read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
 #'
 #' @export
 
@@ -421,5 +421,5 @@ read.MFCLFrq2 <- function(frqfile){
 
 }
 
-#frqfile <- 'C://R4MFCL//test_data//skj_ref_case//skj.frq'
+#frqfile <- 'C:/R4MFCL/test_data/skj_ref_case/skj.frq'
 

--- a/R/read.MFCLFrq.r
+++ b/R/read.MFCLFrq.r
@@ -11,7 +11,9 @@
 #' @return An object of class MFCLFrqStats
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLFrqStats("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLFrq.r
+++ b/R/read.MFCLFrq.r
@@ -216,7 +216,9 @@ read.MFCLLenFreq <- function(frqfile){
 #' @return An object of class MFCLFrq
 #'
 #' @examples
-#' read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
+#' \dontrun{
+#' read.MFCLFrq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLIni.r
+++ b/R/read.MFCLIni.r
@@ -3,15 +3,17 @@
 
 #' read.MFCLIni
 #'
-#' Reads information from the ini file and creates an MFCLIni object
+#' Reads information from the ini file and creates an MFCLIni object.
 #'
-#' @param inifile:  A character string giving the name and path of the ini file to be read
+#' @param inifile A character string giving the name and path of the ini file to be read.
 #'
-#' @return An object of class MFCLIni
+#' @return An object of class MFCLIni.
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLIni("C:/R4MFCL/test_data/skj_ref_case/skj.ini")
 #' read.MFCLIni("/home/robertsc/skj/HCR/run0/skj.ini")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLIni.r
+++ b/R/read.MFCLIni.r
@@ -7,11 +7,10 @@
 #'
 #' @param inifile:  A character string giving the name and path of the ini file to be read
 #'
-#'
 #' @return An object of class MFCLIni
 #'
 #' @examples
-#' read.MFCLIni("C://R4MFCL//test_data//skj_ref_case//skj.ini")
+#' read.MFCLIni("C:/R4MFCL/test_data/skj_ref_case/skj.ini")
 #' read.MFCLIni("/home/robertsc/skj/HCR/run0/skj.ini")
 #'
 #' @export

--- a/R/read.MFCLLenFit.r
+++ b/R/read.MFCLLenFit.r
@@ -3,15 +3,16 @@
 
 #' read.MFCLLenFit
 #'
-#' Reads information from the length.fit file and creates an MFCLLenFit object
+#' Reads information from the length.fit file and creates an MFCLLenFit object.
 #'
-#' @param inifile:  A character string giving the name and path of the length.fit file to be read 
-#' 
+#' @param inifile A character string giving the name and path of the length.fit file to be read.
 #'
 #' @return An object of class MFCLLenFit
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLLenFit("C:/R4MFCL/test_data/skj_ref_case/length.fit")
+#' }
 #'
 #' @export
 
@@ -199,7 +200,3 @@ read.MFCLLenFit2 <- function(lffile, get_lenage = FALSE) {
   slot(obj, 'lenagefits') <- as.data.frame(agelendat) # Force as data frame in case it is NULL (get_lenage==FALSE)
   return(obj)
 }
-
-  
-  
-  

--- a/R/read.MFCLLenFit.r
+++ b/R/read.MFCLLenFit.r
@@ -11,11 +11,11 @@
 #' @return An object of class MFCLLenFit
 #'
 #' @examples
-#' read.MFCLLenFit("C://R4MFCL//test_data//skj_ref_case//length.fit")
+#' read.MFCLLenFit("C:/R4MFCL/test_data/skj_ref_case/length.fit")
 #'
 #' @export
 
-# lffile <- "Q://skj//2016//assessment//RefCase//length.fit"
+# lffile <- "Q:/skj/2016/assessment/RefCase/length.fit"
 
 read.MFCLLenFit <- function(lffile) {
   

--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -230,21 +230,19 @@ read.MFCLFlags <- function(parfile, parobj=NULL, first.yr=1972) {
 #kk <- read.MFCLFlags("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 
-
-
-
-
 #' read.MFCLTagRep
 #'
-#' Reads the TAaRep information from the par file and creates an MFCLTagRep object
+#' Reads the TAaRep information from the par file and creates an MFCLTagRep object.
 #'
-#' @param parfile: A character string giving the name and path of the frq file to be read 
-#' @param parobj:  A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file
+#' @param parfile A character string giving the name and path of the frq file to be read.
+#' @param parobj  A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.
 #'
-#' @return An object of class MFCLTagRep
+#' @return An object of class MFCLTagRep.
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLTagRep("C:/R4MFCL/test_data/skj_ref_case/11.par")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -1,7 +1,6 @@
 #FLR4MFCL - R4MFCL built with FLR classes
 #Copyright (C) 2018  Rob Scott
 
-
 ############################################
 # history of par file additions
 #
@@ -32,8 +31,6 @@
 #
 #___________________________________________________
 
-
-
 ###############################################
 # unexported function to strip Dave's diagnostic stuff out of the par file.
 
@@ -59,28 +56,25 @@ stripDebugNumbers <- function(fstring){
   return(fstring)
 }
 
-
-
-
-
 #' read.MFCLBiol
 #'
-#' Reads the Biol information from the par file and creates an MFCLBiol object
+#' Reads the Biol information from the par file and creates an MFCLBiol object.
 #' Unfortunately you still need to supply the first year of the time series.
 #' Other dimensions are interpreted from the data blocks so care should be taken to check
 #' that these have been reproduced correctly
 #'
-#' @param parfile:  A character string giving the name and path of the frq file to be read 
-#' @param parobj:   A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file
-#' @param first.yr: The first year of the input data time series (default values 1972)
+#' @param parfile A character string giving the name and path of the frq file to be read.
+#' @param parobj A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.
+#' @param first.yr The first year of the input data time series (default values 1972).
 #'
-#' @return An object of class MFCLBiol
+#' @return An object of class MFCLBiol.
 #'
 #' @examples
-#' read.MFCLBiol("C://R4MFCL//test_data//skj_ref_case//11.par")
+#' \dontrun{
+#' read.MFCLBiol("C:/R4MFCL/test_data/skj_ref_case/11.par")
+#' }
 #'
 #' @export
-
 
 read.MFCLBiol <- function(parfile, parobj=NULL, first.yr=1972){
   

--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -473,22 +473,21 @@ read.MFCLRegion <- function(parfile, parobj=NULL, first.yr=1972) {
   
   return(res)
 }
-  
-
-
 
 
 #' read.MFCLSel
 #'
-#' Reads the Selection information from the par file and creates an MFCLSel object
+#' Reads the Selection information from the par file and creates an MFCLSel object.
 #'
-#' @param parfile: A character string giving the name and path of the frq file to be read 
-#' @param parobj:  A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file
+#' @param parfile A character string giving the name and path of the frq file to be read.
+#' @param parobj A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.
 #'
-#' @return An object of class MFCLSel
+#' @return An object of class MFCLSel.
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLSel("C:/R4MFCL/test_data/skj_ref_case/11.par")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -164,7 +164,7 @@ read.MFCLBiol <- function(parfile, parobj=NULL, first.yr=1972){
   return(res)
 }  
 
-#kk <- read.MFCLBiol("C://R4MFCL//test_data//skj_ref_case//11.par")
+#kk <- read.MFCLBiol("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 
 
@@ -179,7 +179,7 @@ read.MFCLBiol <- function(parfile, parobj=NULL, first.yr=1972){
 #' @return An object of class MFCLFlags
 #'
 #' @examples
-#' read.MFCLFlags("C://R4MFCL//test_data//skj_ref_case//11.par")
+#' read.MFCLFlags("C:/R4MFCL/test_data/skj_ref_case/11.par")
 #'
 #' @export
 
@@ -227,7 +227,7 @@ read.MFCLFlags <- function(parfile, parobj=NULL, first.yr=1972) {
   return(res)
 }
 
-#kk <- read.MFCLFlags("C://R4MFCL//test_data//skj_ref_case//11.par")
+#kk <- read.MFCLFlags("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 
 
@@ -244,7 +244,7 @@ read.MFCLFlags <- function(parfile, parobj=NULL, first.yr=1972) {
 #' @return An object of class MFCLTagRep
 #'
 #' @examples
-#' read.MFCLTagRep("C://R4MFCL//test_data//skj_ref_case//11.par")
+#' read.MFCLTagRep("C:/R4MFCL/test_data/skj_ref_case/11.par")
 #'
 #' @export
 
@@ -289,7 +289,7 @@ read.MFCLTagRep <- function(parfile, parobj=NULL, first.yr=1972) {
   return(res)
 }
 
-#kk <- read.MFCLTagRep("C://R4MFCL//test_data//skj_ref_case//11.par")
+#kk <- read.MFCLTagRep("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 
 
@@ -306,7 +306,7 @@ read.MFCLTagRep <- function(parfile, parobj=NULL, first.yr=1972) {
 #' @return An object of class MFCLRec
 #'
 #' @examples
-#' read.MFCLRec("C://R4MFCL//test_data//skj_ref_case//11.par")
+#' read.MFCLRec("C:/R4MFCL/test_data/skj_ref_case/11.par")
 #'
 #' @export
 
@@ -392,7 +392,7 @@ read.MFCLRec <- function(parfile, parobj=NULL, first.yr=1972) {
 #' @return An object of class MFCLRec
 #'
 #' @examples
-#' read.MFCLRegion("C://R4MFCL//test_data//skj_ref_case//11.par")
+#' read.MFCLRegion("C:/R4MFCL/test_data/skj_ref_case/11.par")
 #'
 #' @export
 
@@ -492,7 +492,7 @@ read.MFCLRegion <- function(parfile, parobj=NULL, first.yr=1972) {
 #' @return An object of class MFCLSel
 #'
 #' @examples
-#' read.MFCLSel("C://R4MFCL//test_data//skj_ref_case//11.par")
+#' read.MFCLSel("C:/R4MFCL/test_data/skj_ref_case/11.par")
 #'
 #' @export
 
@@ -601,7 +601,7 @@ read.MFCLSel <- function(parfile, parobj=NULL, first.yr=1972) {
 #' @return An object of class MFCLParBit
 #'
 #' @examples
-#' read.MFCLParBits("C://R4MFCL//test_data//skj_ref_case//11.par")
+#' read.MFCLParBits("C:/R4MFCL/test_data/skj_ref_case/11.par")
 #'
 #' @export
 
@@ -693,7 +693,7 @@ read.MFCLParBits <- function(parfile, parobj=NULL, first.yr=1972) {
 #' @return An object of class MFCLPar
 #'
 #' @examples
-#' read.MFCLPar("C://R4MFCL//test_data//skj_ref_case//11.par")
+#' read.MFCLPar("C:/R4MFCL/test_data/skj_ref_case/11.par")
 #'
 #' @export
 

--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -167,8 +167,6 @@ read.MFCLBiol <- function(parfile, parobj=NULL, first.yr=1972){
 #kk <- read.MFCLBiol("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 
-
-
 #' read.MFCLFlags
 #'
 #' Reads the Flag information from the par file and creates an MFCLFlags object
@@ -179,7 +177,9 @@ read.MFCLBiol <- function(parfile, parobj=NULL, first.yr=1972){
 #' @return An object of class MFCLFlags
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLFlags("C:/R4MFCL/test_data/skj_ref_case/11.par")
+#' }
 #'
 #' @export
 
@@ -733,15 +733,3 @@ read.MFCLPar <- function(parfile, first.yr=1972) {
 
   return(res)
 }
-
-
-
-
-
-
-
-
-
-
-
-  

--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -671,24 +671,22 @@ read.MFCLParBits <- function(parfile, parobj=NULL, first.yr=1972) {
   return(res)
 }
 
-
 #parfile <- "Q:/yft/2017/assessment/Model_Runs/Sensitivity_annualSRR_steepness0.65/12.par"
-
-
-
 
 
 #' read.MFCLPar
 #'
-#' Reads information from the par file and creates an MFCLPar object
+#' Reads information from the par file and creates an MFCLPar object.
 #'
-#' @param parfile:  A character string giving the name and path of the frq file to be read 
-#' @param first.yr: The first year of the input data time series (default values 1972)
+#' @param parfile A character string giving the name and path of the frq file to be read.
+#' @param first.yr The first year of the input data time series (default values 1972).
 #'
-#' @return An object of class MFCLPar
+#' @return An object of class MFCLPar.
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLPar("C:/R4MFCL/test_data/skj_ref_case/11.par")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -375,21 +375,20 @@ read.MFCLRec <- function(parfile, parobj=NULL, first.yr=1972) {
 }
 
 
-
-
-
 #' read.MFCLRegion
 #'
-#' Reads the region specific information from the par file and creates an MFCLRegion object
+#' Reads the region specific information from the par file and creates an MFCLRegion object.
 #'
-#' @param parfile: A character string giving the name and path of the frq file to be read 
-#' @param parobj:  A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file
-#' @param first.yr: The first year of the input data time series (default value 1972)
+#' @param parfile A character string giving the name and path of the frq file to be read.
+#' @param parobj A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.
+#' @param first.yr The first year of the input data time series (default value 1972).
 #'
-#' @return An object of class MFCLRec
+#' @return An object of class MFCLRec.
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLRegion("C:/R4MFCL/test_data/skj_ref_case/11.par")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -290,21 +290,20 @@ read.MFCLTagRep <- function(parfile, parobj=NULL, first.yr=1972) {
 #kk <- read.MFCLTagRep("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 
-
-
-
 #' read.MFCLRec
 #'
-#' Reads the recruitment information from the par file and creates an MFCLec object
+#' Reads the recruitment information from the par file and creates an MFCLec object.
 #'
-#' @param parfile: A character string giving the name and path of the frq file to be read 
-#' @param parobj:  A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file
-#' @param first.yr: The first year of the input data time series (default value 1972)
+#' @param parfile A character string giving the name and path of the frq file to be read.
+#' @param parobj A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.
+#' @param first.yr The first year of the input data time series (default value 1972).
 #'
-#' @return An object of class MFCLRec
+#' @return An object of class MFCLRec.
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLRec("C:/R4MFCL/test_data/skj_ref_case/11.par")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -584,19 +584,19 @@ read.MFCLSel <- function(parfile, parobj=NULL, first.yr=1972) {
 }
 
 
-
-
 #' read.MFCLParBits
 #'
-#' Reads the remaining information from the par file and creates an MFCLParBits object
+#' Reads the remaining information from the par file and creates an MFCLParBits object.
 #'
-#' @param parfile: A character string giving the name and path of the frq file to be read 
-#' @param parobj:  A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file
+#' @param parfile A character string giving the name and path of the frq file to be read.
+#' @param parobj A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.
 #'
-#' @return An object of class MFCLParBit
+#' @return An object of class MFCLParBit.
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLParBits("C:/R4MFCL/test_data/skj_ref_case/11.par")
+#' }
 #'
 #' @export
 

--- a/R/read.MFCLRep.r
+++ b/R/read.MFCLRep.r
@@ -3,16 +3,17 @@
 
 #' read.MFCLRep
 #'
-#' Reads information from the .rep file and creates an MFCLRep object
+#' Reads information from the .rep file and creates an MFCLRep object.
 #'
-#' @param inifile:  A character string giving the name and path of the .rep file to be read 
-#' 
+#' @param inifile A character string giving the name and path of the .rep file to be read.
 #'
 #' @return An object of class MFCLRep
 #'
 #' @examples
-#' read.MFCLIni("C:/R4MFCL/test_data/skj_ref_case/plot-out.par.rep")
-#' read.MFCLIni("/home/roberts/skj/HCR/run0/plot-out.par.rep")
+#' \dontrun{
+#' read.MFCLRep("C:/R4MFCL/test_data/skj_ref_case/plot-out.par.rep")
+#' read.MFCLRep("/home/roberts/skj/HCR/run0/plot-out.par.rep")
+#' }
 #'
 #' @export
 
@@ -20,7 +21,6 @@ read.MFCLRep <- function(repfile) {
   
   trim.leading  <- function(x) sub("^\\s+", "", x) 
   splitter      <- function(ff, tt, ll=1, inst=1) unlist(strsplit(trim.leading(ff[grep(tt, ff)[inst]+ll]),split="[[:blank:]]+")) 
-  
   
   res <- new("MFCLRep")
   
@@ -283,4 +283,3 @@ read.SBSBF0 <- function(repfile, sbsbf0 = 'latest', ...) {
   return(returnval)
 
 }
-

--- a/R/read.MFCLRep.r
+++ b/R/read.MFCLRep.r
@@ -11,7 +11,7 @@
 #' @return An object of class MFCLRep
 #'
 #' @examples
-#' read.MFCLIni("C://R4MFCL//test_data//skj_ref_case//plot-out.par.rep")
+#' read.MFCLIni("C:/R4MFCL/test_data/skj_ref_case/plot-out.par.rep")
 #' read.MFCLIni("/home/roberts/skj/HCR/run0/plot-out.par.rep")
 #'
 #' @export

--- a/R/read.MFCLTag.r
+++ b/R/read.MFCLTag.r
@@ -11,7 +11,7 @@
 #' @return An object of class character vector
 #'
 #' @examples
-#' read.MFCLTag("C://R4MFCL//test_data//skj_ref_case//skj.tag")
+#' read.MFCLTag("C:/R4MFCL/test_data/skj_ref_case/skj.tag")
 #'
 #' @export
 

--- a/R/read.MFCLTag.r
+++ b/R/read.MFCLTag.r
@@ -3,15 +3,16 @@
 
 #' read.MFCLTag
 #'
-#' Reads information from the tag file and creates  object
+#' Reads information from the tag file and creates object.
 #'
-#' @param tagfile:  A character string giving the name and path of the tag file to be read 
-#' 
+#' @param tagfile A character string giving the name and path of the tag file to be read.
 #'
-#' @return An object of class character vector
+#' @return An object of class character vector.
 #'
 #' @examples
+#' \dontrun{
 #' read.MFCLTag("C:/R4MFCL/test_data/skj_ref_case/skj.tag")
+#' }
 #'
 #' @export
 

--- a/R/trim.r
+++ b/R/trim.r
@@ -3,23 +3,24 @@
 
 #' trim
 #'
-#' trim MFCL objects using named dimensions
+#' Trim MFCL objects using named dimensions
 #'
-#' @param x:    An object of class MFCLX.
+#' @param x An object of class MFCL*.
 #'
-#' @param ... Additional argument list that might not ever
-#'  be used.
+#' @param ... Additional argument list that might not ever be used.
 #'
-#' @return An updated object of the same class
+#' @return An updated object of the same class.
 #' 
-#' @seealso \code{\link{MFCLFrq}},  \code{\link{MFCLPar}} and \code{\link{MFCLPar}}
+#' @seealso \code{\link{MFCLFrq}}, \code{\link{MFCLPar}} and \code{\link{MFCLPar}}
 #' 
 #' @export
 #' @docType methods
 #' @rdname mfcl-methods
 #'
 #' @examples
+#' \dontrun{
 #' trim(MFCLFrq(), year=1990:1995)
+#' }
 #'
 #' @aliases mfcl
 

--- a/R/update.r
+++ b/R/update.r
@@ -5,12 +5,11 @@
 #'
 #' Update MFCL objects with new values
 #'
-#' @param obj:    An object of class MFCLX.
+#' @param obj An object of class MFCL*.
 #'
-#' @param ... Additional argument list that might not ever
-#'  be used.
+#' @param ... Additional argument list that might not ever be used.
 #'
-#' @return An updated object of the same class
+#' @return An updated object of the same class.
 #' 
 #' @seealso \code{\link{read.MFCLFrq}} and \code{\link{read.MFCLPar}}
 #' 
@@ -19,10 +18,13 @@
 #' @rdname mfcl-methods
 #'
 #' @examples
+#' \dontrun{
 #' update(MFCLFrq())
+#' }
 #'
 #' @aliases mfcl
-#setGeneric('update', function(object, ...) standardGeneric('update')) 
+
+#setGeneric('update', function(object, ...) standardGeneric('update'))
 
 setMethod("update", signature(object="MFCLFrq"), function(object, years, fisheries, multiplier, quantity, ...){
             

--- a/R/window.r
+++ b/R/window.r
@@ -3,20 +3,19 @@
 
 #' window
 #'
-#' subset MFCL objects between the times start and end.
+#' Subset MFCL objects between the times start and end.
 #'
-#' @param x:    An object of class MFCLX.
+#' @param x An object of class MFCLX.
 #' 
-#' @param start:    The start time of the period of interest
+#' @param start The start time of the period of interest
 #' 
-#' @param end:    The end time of the period of interest.
+#' @param end The end time of the period of interest.
 #' 
-#' @param extend: logical. If true the start and end times can extend the time series. If false any attempt to extend the series prompts a warning and is ignored.
+#' @param extend Logical. If true the start and end times can extend the time series. If false any attempt to extend the series prompts a warning and is ignored.
 #'
-#' @param ... Additional argument list that might not ever
-#'  be used.
+#' @param ... Additional argument list that might not ever be used.
 #'
-#' @return An updated object of the same class
+#' @return An updated object of the same class.
 #' 
 #' @seealso \code{\link{MFCLFrq}},  \code{\link{MFCLPar}} and \code{\link{MFCLPar}}
 #' 
@@ -25,14 +24,14 @@
 #' @rdname mfcl-methods
 #'
 #' @examples
+#' \dontrun{
 #' window(MFCLFrq(), start = 1990, end = 1995)
+#' }
 #'
 #' @aliases mfcl
 
-
 setMethod("window", signature(x="MFCLFrq"), 
           function(x, start=range(x)['minyear'], end=range(x)['maxyear'], extend=FALSE, ...){
-            
             
             if(start < range(x)['minyear'] | end > range(x)['maxyear'])
               stop("Error: This method does not yet allow the extension of MFCL objects beyond their current year range")

--- a/R/write.MFCLIni.r
+++ b/R/write.MFCLIni.r
@@ -2,10 +2,10 @@
 #Copyright (C) 2018  Rob Scott
 
 
-# x    <- read.MFCLPar("C://temp//bet_2014_assessment//Model_runs//2014s//Run143//10.par", first.yr=1952)
-# file <- "C://temp//par_crap"
+# x    <- read.MFCLPar("C:/temp/bet_2014_assessment/Model_runs/2014s/Run143/10.par", first.yr=1952)
+# file <- "C:/temp/par_crap"
 # append <- FALSE
-# source("C://R4MFCL//FLR4MFCL//R//write.MFCLPar.r")
+# source("C:/R4MFCL/FLR4MFCL/R/write.MFCLPar.r")
 
 # write.par(x, file=file)
 

--- a/R/write.MFCLPar.r
+++ b/R/write.MFCLPar.r
@@ -2,10 +2,10 @@
 #Copyright (C) 2018  Rob Scott
 
 
-# x    <- read.MFCLPar("C://temp//bet_2014_assessment//Model_runs//2014s//Run143//10.par", first.yr=1952)
-# file <- "C://temp//par_crap"
+# x <- read.MFCLPar("C:/temp/bet_2014_assessment/Model_runs/2014s/Run143/10.par", first.yr=1952)
+# file <- "C:/temp/par_crap"
 # append <- FALSE
-# source("C://R4MFCL//FLR4MFCL//R//write.MFCLPar.r")
+# source("C:/R4MFCL/FLR4MFCL/R/write.MFCLPar.r")
 
 # write.par(x, file=file)
 

--- a/man/checkUnitDimnames.Rd
+++ b/man/checkUnitDimnames.Rd
@@ -11,17 +11,18 @@ checkUnitDimnames(obj, nfisheries)
 
 \item{nfisheries}{The number of fisheries in the model}
 
-\item{...}{Additional argument list that might not ever
-be used.}
+\item{...}{Additional argument list that might not ever be used.}
 }
 \value{
 Returns an object of the same class but with FLQuant unit dimension
 re-ordered as appropriate.
 }
 \description{
-Re-orders the unit dimnames in ascending order instead 
+Re-orders the unit dimnames in ascending order instead
 of default ordering of FLQuant method which uses the year dimension
 }
 \examples{
+\dontrun{
 checkUnitDimnames(MFCLRep())
+}
 }

--- a/man/flagDiff.Rd
+++ b/man/flagDiff.Rd
@@ -7,7 +7,7 @@
 flagDiff(par1, par2)
 }
 \arguments{
-\item{par}{A object of class MFCLPar}
+\item{par}{An object of class MFCLPar}
 }
 \value{
 A data frame of flag settings for par1 and par2
@@ -16,6 +16,9 @@ A data frame of flag settings for par1 and par2
 flag differences between two par files
 }
 \examples{
-flagDiff(par, par)
+data(par)
+par1 <- par2 <- par
+flags(par2)[20,"value"] <- 12
+flagDiff(par1, par2)
 
 }

--- a/man/flagSummary.Rd
+++ b/man/flagSummary.Rd
@@ -7,7 +7,7 @@
 flagSummary(par, type)
 }
 \arguments{
-\item{par}{A object of class MFCLPar}
+\item{par}{An object of class MFCLPar}
 
 \item{type}{A character string specifying the MFCL User Guide section}
 }
@@ -18,6 +18,7 @@ A data frame of flag settings
 flag settings summarised by MFCL User Guide sections
 }
 \examples{
+data(par)
 flagSummary(par, 'projection')
 
 }

--- a/man/gradients.Rd
+++ b/man/gradients.Rd
@@ -7,9 +7,9 @@
 gradients(grads = "sorted_gradient.rpt", parnames = "xinit.rpt")
 }
 \arguments{
-\item{grads:}{text string of input file name for sorted gradients}
+\item{grads}{text string of input file name for sorted gradients}
 
-\item{parnames:}{text string of input file name for parameter names}
+\item{parnames}{text string of input file name for parameter names}
 }
 \value{
 data.frame of parameter gradients
@@ -18,6 +18,8 @@ data.frame of parameter gradients
 Returns a data.frame of parameters and their gradients in reverse order
 }
 \examples{
+\dontrun{
 gradients()
+}
 
 }

--- a/man/hcr_funcs.Rd
+++ b/man/hcr_funcs.Rd
@@ -70,14 +70,13 @@ Parameters are 'sbsbf0_min', 'sbsbf0_max', 'sbsbf0_step_min', 'sbsbf0_step_max',
 Adding 'curve' to allow for asymptotic out_left
 }
 \examples{
-
-Without constraint
+# Without constraint
 msectrl <- MFCLMSEControl()
 hcr(msectrl) <- "hcr_threshold"
 hcr_params(msectrl) <- c(sbsbf0_min=0.1, sbsbf0_max=0.5, out_min=0.0, out_max=1.2)
 eval_hcr(msectrl, sbsbf0=0.3) # 0.5
 
-With a constraint of 15\% each way
+# With a constraint of 15\% each way
 msectrl2 <- MFCLMSEControl()
 hcr(msectrl2) <- "hcr_threshold_constrained"
 hcr_params(msectrl2) <- c(sbsbf0_min=0.1, sbsbf0_max=0.5, out_min=0.0, out_max=1.2, max_change_up=1.15, max_change_down=0.85)

--- a/man/mfcl-methods.Rd
+++ b/man/mfcl-methods.Rd
@@ -74,13 +74,15 @@ be used.}
 
 \item{outpar}{The name of the output par file.}
 
+\item{depletion_method}{The method for calculating depletion (default SBSBF0).}
+
 \item{object:}{An object of class MFCLPar}
 
 \item{frq:}{The corresponding MFCLFrq for the MFCLPar}
 
 \item{switch}{Optional numeric vector of additional flag settings.}
 
-\item{depletion_method:}{the method for calculating depletion (default SBSBF0)}
+\item{obj}{An object of class list containing the rep files from the final assessment and each retrospective peel.}
 
 \item{obj:}{An object of class MFCLX.}
 
@@ -95,7 +97,7 @@ be used.}
 \value{
 Creates a text file at the specified location.
 
-A numerric value of mohn's rho
+A numeric value of mohn's rho.
 
 An updated object of the same class
 
@@ -119,7 +121,9 @@ Update MFCL objects with new values
 subset MFCL objects between the times start and end.
 }
 \examples{
+\dontrun{
 mohns_rho(retros)
+}
 plot(MFCLFrq())
 
 trim(MFCLFrq(), year=1990:1995)

--- a/man/mfcl-methods.Rd
+++ b/man/mfcl-methods.Rd
@@ -63,20 +63,22 @@ mohns_rho(object, ...)
 )
 }
 \arguments{
+\item{frq}{An object of class MFCLFrq.}
+
 \item{...}{Additional argument list that might not ever
 be used.}
 
+\item{spp}{Character string with 3 letter species code - optional but required to produce the .cfg file if missing.}
+
+\item{par}{An object of class MFCLPar.}
+
+\item{outpar}{The name of the output par file.}
+
 \item{object:}{An object of class MFCLPar}
 
-\item{frq:}{An object of class MFCLFrq.}
+\item{frq:}{The corresponding MFCLFrq for the MFCLPar}
 
-\item{par:}{An object of class MFCLPar.}
-
-\item{outpar:}{The name of the output par file}
-
-\item{switch:}{Optional numeric vector of additional flag settings}
-
-\item{spp:}{character string with 3 letter species code - optional but required to produce the .cfg file if missing}
+\item{switch}{Optional numeric vector of additional flag settings.}
 
 \item{depletion_method:}{the method for calculating depletion (default SBSBF0)}
 
@@ -117,7 +119,6 @@ Update MFCL objects with new values
 subset MFCL objects between the times start and end.
 }
 \examples{
-write(MFCLFrqStats())
 mohns_rho(retros)
 plot(MFCLFrq())
 

--- a/man/mfcl-methods.Rd
+++ b/man/mfcl-methods.Rd
@@ -76,6 +76,8 @@ be used.}
 
 \item{depletion_method}{The method for calculating depletion (default SBSBF0).}
 
+\item{x}{An object of class MFCL*.}
+
 \item{object:}{An object of class MFCLPar}
 
 \item{frq:}{The corresponding MFCLFrq for the MFCLPar}
@@ -99,7 +101,7 @@ Creates a text file at the specified location.
 
 A numeric value of mohn's rho.
 
-An updated object of the same class
+An updated object of the same class.
 
 An updated object of the same class
 
@@ -114,7 +116,7 @@ Calculate mohns rho for retrospective analyses
 
 Plot MFCL objects
 
-trim MFCL objects using named dimensions
+Trim MFCL objects using named dimensions
 
 Update MFCL objects with new values
 
@@ -128,7 +130,9 @@ mohns_rho(retros)
 plot(MFCLFrq())
 }
 
+\dontrun{
 trim(MFCLFrq(), year=1990:1995)
+}
 
 update(MFCLFrq())
 
@@ -142,7 +146,7 @@ window(MFCLFrq(), start = 1990, end = 1995)
 
 \code{\link{SBSBF0}} and \code{\link{MFCLRep}}
 
-\code{\link{MFCLFrq}},  \code{\link{MFCLPar}} and \code{\link{MFCLPar}}
+\code{\link{MFCLFrq}}, \code{\link{MFCLPar}} and \code{\link{MFCLPar}}
 
 \code{\link{read.MFCLFrq}} and \code{\link{read.MFCLPar}}
 

--- a/man/mfcl-methods.Rd
+++ b/man/mfcl-methods.Rd
@@ -124,7 +124,9 @@ subset MFCL objects between the times start and end.
 \dontrun{
 mohns_rho(retros)
 }
+\dontrun{
 plot(MFCLFrq())
+}
 
 trim(MFCLFrq(), year=1990:1995)
 

--- a/man/mfcl-methods.Rd
+++ b/man/mfcl-methods.Rd
@@ -84,9 +84,9 @@ be used.}
 
 \item{switch}{Optional numeric vector of additional flag settings.}
 
-\item{obj}{An object of class list containing the rep files from the final assessment and each retrospective peel.}
-
 \item{obj:}{An object of class MFCLX.}
+
+\item{obj}{An object of class MFCL*.}
 
 \item{x:}{An object of class MFCLX.}
 
@@ -103,7 +103,7 @@ A numeric value of mohn's rho.
 
 An updated object of the same class.
 
-An updated object of the same class
+An updated object of the same class.
 
 An updated object of the same class
 }
@@ -134,7 +134,9 @@ plot(MFCLFrq())
 trim(MFCLFrq(), year=1990:1995)
 }
 
+\dontrun{
 update(MFCLFrq())
+}
 
 window(MFCLFrq(), start = 1990, end = 1995)
 

--- a/man/mfcl-methods.Rd
+++ b/man/mfcl-methods.Rd
@@ -65,8 +65,7 @@ mohns_rho(object, ...)
 \arguments{
 \item{frq}{An object of class MFCLFrq.}
 
-\item{...}{Additional argument list that might not ever
-be used.}
+\item{...}{Additional argument list that might not ever be used.}
 
 \item{spp}{Character string with 3 letter species code - optional but required to produce the .cfg file if missing.}
 
@@ -76,7 +75,13 @@ be used.}
 
 \item{depletion_method}{The method for calculating depletion (default SBSBF0).}
 
-\item{x}{An object of class MFCL*.}
+\item{x}{An object of class MFCLX.}
+
+\item{start}{The start time of the period of interest}
+
+\item{end}{The end time of the period of interest.}
+
+\item{extend}{Logical. If true the start and end times can extend the time series. If false any attempt to extend the series prompts a warning and is ignored.}
 
 \item{object:}{An object of class MFCLPar}
 
@@ -87,14 +92,6 @@ be used.}
 \item{obj:}{An object of class MFCLX.}
 
 \item{obj}{An object of class MFCL*.}
-
-\item{x:}{An object of class MFCLX.}
-
-\item{start:}{The start time of the period of interest}
-
-\item{end:}{The end time of the period of interest.}
-
-\item{extend:}{logical. If true the start and end times can extend the time series. If false any attempt to extend the series prompts a warning and is ignored.}
 }
 \value{
 Creates a text file at the specified location.
@@ -105,7 +102,7 @@ An updated object of the same class.
 
 An updated object of the same class.
 
-An updated object of the same class
+An updated object of the same class.
 }
 \description{
 Strip out effort devs from an MFCLPar object including the realisations information from the frq file
@@ -120,7 +117,7 @@ Trim MFCL objects using named dimensions
 
 Update MFCL objects with new values
 
-subset MFCL objects between the times start and end.
+Subset MFCL objects between the times start and end.
 }
 \examples{
 \dontrun{
@@ -138,7 +135,9 @@ trim(MFCLFrq(), year=1990:1995)
 update(MFCLFrq())
 }
 
+\dontrun{
 window(MFCLFrq(), start = 1990, end = 1995)
+}
 
 }
 \seealso{

--- a/man/qts.Rd
+++ b/man/qts.Rd
@@ -7,15 +7,16 @@
 qts(quant)
 }
 \arguments{
-\item{quant:}{An FLQuant object}
+\item{quant}{An FLQuant object.}
 }
 \value{
-An object of class FLQuant
+An object of class FLQuant.
 }
 \description{
 Returns a quarterly time series from a seasonally structured FLQuant.
 }
 \examples{
-flq(stock.n(ple4))
+data(ple4)
+qts(stock.n(ple4))
 
 }

--- a/man/read.MFCLBiol.Rd
+++ b/man/read.MFCLBiol.Rd
@@ -7,22 +7,24 @@
 read.MFCLBiol(parfile, parobj = NULL, first.yr = 1972)
 }
 \arguments{
-\item{parfile:}{A character string giving the name and path of the frq file to be read}
+\item{parfile}{A character string giving the name and path of the frq file to be read.}
 
-\item{parobj:}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file}
+\item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr:}{The first year of the input data time series (default values 1972)}
+\item{first.yr}{The first year of the input data time series (default values 1972).}
 }
 \value{
-An object of class MFCLBiol
+An object of class MFCLBiol.
 }
 \description{
-Reads the Biol information from the par file and creates an MFCLBiol object
+Reads the Biol information from the par file and creates an MFCLBiol object.
 Unfortunately you still need to supply the first year of the time series.
 Other dimensions are interpreted from the data blocks so care should be taken to check
 that these have been reproduced correctly
 }
 \examples{
-read.MFCLBiol("C://R4MFCL//test_data//skj_ref_case//11.par")
+\dontrun{
+read.MFCLBiol("C:/R4MFCL/test_data/skj_ref_case/11.par")
+}
 
 }

--- a/man/read.MFCLCatch.Rd
+++ b/man/read.MFCLCatch.Rd
@@ -20,7 +20,9 @@ An object of class MFCLCatch
 Reads information from the catch.rep file and creates an MFCLCatch object
 }
 \examples{
+\dontrun{
 read.MFCLCatch("C:/R4MFCL/test_data/skj_ref_case/catch.rep", dimensions(par))
 read.MFCLCatch("/home/robertsc/skj/HCR/run0/catch.rep", dimensions(par))
+}
 
 }

--- a/man/read.MFCLCatch.Rd
+++ b/man/read.MFCLCatch.Rd
@@ -20,7 +20,7 @@ An object of class MFCLCatch
 Reads information from the catch.rep file and creates an MFCLCatch object
 }
 \examples{
-read.MFCLCatch("C://R4MFCL//test_data//skj_ref_case//catch.rep", dimensions(par))
+read.MFCLCatch("C:/R4MFCL/test_data/skj_ref_case/catch.rep", dimensions(par))
 read.MFCLCatch("/home/robertsc/skj/HCR/run0/catch.rep", dimensions(par))
 
 }

--- a/man/read.MFCLFlags.Rd
+++ b/man/read.MFCLFlags.Rd
@@ -18,6 +18,8 @@ An object of class MFCLFlags
 Reads the Flag information from the par file and creates an MFCLFlags object
 }
 \examples{
+\dontrun{
 read.MFCLFlags("C:/R4MFCL/test_data/skj_ref_case/11.par")
+}
 
 }

--- a/man/read.MFCLFlags.Rd
+++ b/man/read.MFCLFlags.Rd
@@ -18,6 +18,6 @@ An object of class MFCLFlags
 Reads the Flag information from the par file and creates an MFCLFlags object
 }
 \examples{
-read.MFCLFlags("C://R4MFCL//test_data//skj_ref_case//11.par")
+read.MFCLFlags("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 }

--- a/man/read.MFCLFrq.Rd
+++ b/man/read.MFCLFrq.Rd
@@ -16,6 +16,8 @@ An object of class MFCLFrq
 Reads the entire contents of the frq file
 }
 \examples{
-read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
+\dontrun{
+read.MFCLFrq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
+}
 
 }

--- a/man/read.MFCLFrq.Rd
+++ b/man/read.MFCLFrq.Rd
@@ -16,6 +16,6 @@ An object of class MFCLFrq
 Reads the entire contents of the frq file
 }
 \examples{
-read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='//'))
+read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
 
 }

--- a/man/read.MFCLFrq2.Rd
+++ b/man/read.MFCLFrq2.Rd
@@ -16,6 +16,8 @@ An object of class MFCLFrq
 Reads the entire contents of the frq file
 }
 \examples{
-read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
+\dontrun{
+read.MFCLFrq2(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
+}
 
 }

--- a/man/read.MFCLFrq2.Rd
+++ b/man/read.MFCLFrq2.Rd
@@ -16,6 +16,6 @@ An object of class MFCLFrq
 Reads the entire contents of the frq file
 }
 \examples{
-read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='//'))
+read.MFCLLenFreq(paste(system.file('data', package='FLR4MFCL'), 'skj.frq', sep='/'))
 
 }

--- a/man/read.MFCLFrqStats.Rd
+++ b/man/read.MFCLFrqStats.Rd
@@ -16,6 +16,6 @@ An object of class MFCLFrqStats
 Extracts the essential ranges and dimensions from the frq file
 }
 \examples{
-read.MFCLFrqStats("C://R4MFCL//test_data//skj_ref_case//skj.frq")
+read.MFCLFrqStats("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
 
 }

--- a/man/read.MFCLFrqStats.Rd
+++ b/man/read.MFCLFrqStats.Rd
@@ -16,6 +16,8 @@ An object of class MFCLFrqStats
 Extracts the essential ranges and dimensions from the frq file
 }
 \examples{
+\dontrun{
 read.MFCLFrqStats("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
+}
 
 }

--- a/man/read.MFCLIni.Rd
+++ b/man/read.MFCLIni.Rd
@@ -7,16 +7,18 @@
 read.MFCLIni(inifile, nseasons = 4)
 }
 \arguments{
-\item{inifile:}{A character string giving the name and path of the ini file to be read}
+\item{inifile}{A character string giving the name and path of the ini file to be read.}
 }
 \value{
-An object of class MFCLIni
+An object of class MFCLIni.
 }
 \description{
-Reads information from the ini file and creates an MFCLIni object
+Reads information from the ini file and creates an MFCLIni object.
 }
 \examples{
+\dontrun{
 read.MFCLIni("C:/R4MFCL/test_data/skj_ref_case/skj.ini")
 read.MFCLIni("/home/robertsc/skj/HCR/run0/skj.ini")
+}
 
 }

--- a/man/read.MFCLIni.Rd
+++ b/man/read.MFCLIni.Rd
@@ -16,7 +16,7 @@ An object of class MFCLIni
 Reads information from the ini file and creates an MFCLIni object
 }
 \examples{
-read.MFCLIni("C://R4MFCL//test_data//skj_ref_case//skj.ini")
+read.MFCLIni("C:/R4MFCL/test_data/skj_ref_case/skj.ini")
 read.MFCLIni("/home/robertsc/skj/HCR/run0/skj.ini")
 
 }

--- a/man/read.MFCLLenFit.Rd
+++ b/man/read.MFCLLenFit.Rd
@@ -16,6 +16,6 @@ An object of class MFCLLenFit
 Reads information from the length.fit file and creates an MFCLLenFit object
 }
 \examples{
-read.MFCLLenFit("C://R4MFCL//test_data//skj_ref_case//length.fit")
+read.MFCLLenFit("C:/R4MFCL/test_data/skj_ref_case/length.fit")
 
 }

--- a/man/read.MFCLLenFit.Rd
+++ b/man/read.MFCLLenFit.Rd
@@ -7,15 +7,17 @@
 read.MFCLLenFit(lffile)
 }
 \arguments{
-\item{inifile:}{A character string giving the name and path of the length.fit file to be read}
+\item{inifile}{A character string giving the name and path of the length.fit file to be read.}
 }
 \value{
 An object of class MFCLLenFit
 }
 \description{
-Reads information from the length.fit file and creates an MFCLLenFit object
+Reads information from the length.fit file and creates an MFCLLenFit object.
 }
 \examples{
+\dontrun{
 read.MFCLLenFit("C:/R4MFCL/test_data/skj_ref_case/length.fit")
+}
 
 }

--- a/man/read.MFCLLenFreq.Rd
+++ b/man/read.MFCLLenFreq.Rd
@@ -16,6 +16,8 @@ An object of class MFCLLenFreq
 Extracts the length frequency data from the frq file
 }
 \examples{
+\dontrun{
 read.MFCLLenFreq("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
+}
 
 }

--- a/man/read.MFCLLenFreq.Rd
+++ b/man/read.MFCLLenFreq.Rd
@@ -16,6 +16,6 @@ An object of class MFCLLenFreq
 Extracts the length frequency data from the frq file
 }
 \examples{
-read.MFCLLenFreq("C://R4MFCL//test_data//skj_ref_case//skj.frq")
+read.MFCLLenFreq("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
 
 }

--- a/man/read.MFCLLenFreq2.Rd
+++ b/man/read.MFCLLenFreq2.Rd
@@ -16,6 +16,6 @@ An object of class MFCLLenFreq
 Extracts the length frequency data from Mufdagr output
 }
 \examples{
-read.MFCLLenFreq("C://R4MFCL//test_data//skj_ref_case//skj.frq")
+read.MFCLLenFreq("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
 
 }

--- a/man/read.MFCLLenFreq2.Rd
+++ b/man/read.MFCLLenFreq2.Rd
@@ -16,6 +16,8 @@ An object of class MFCLLenFreq
 Extracts the length frequency data from Mufdagr output
 }
 \examples{
-read.MFCLLenFreq("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
+\dontrun{
+read.MFCLLenFreq2("C:/R4MFCL/test_data/skj_ref_case/skj.frq")
+}
 
 }

--- a/man/read.MFCLPar.Rd
+++ b/man/read.MFCLPar.Rd
@@ -7,17 +7,19 @@
 read.MFCLPar(parfile, first.yr = 1972)
 }
 \arguments{
-\item{parfile:}{A character string giving the name and path of the frq file to be read}
+\item{parfile}{A character string giving the name and path of the frq file to be read.}
 
-\item{first.yr:}{The first year of the input data time series (default values 1972)}
+\item{first.yr}{The first year of the input data time series (default values 1972).}
 }
 \value{
-An object of class MFCLPar
+An object of class MFCLPar.
 }
 \description{
-Reads information from the par file and creates an MFCLPar object
+Reads information from the par file and creates an MFCLPar object.
 }
 \examples{
+\dontrun{
 read.MFCLPar("C:/R4MFCL/test_data/skj_ref_case/11.par")
+}
 
 }

--- a/man/read.MFCLPar.Rd
+++ b/man/read.MFCLPar.Rd
@@ -18,6 +18,6 @@ An object of class MFCLPar
 Reads information from the par file and creates an MFCLPar object
 }
 \examples{
-read.MFCLPar("C://R4MFCL//test_data//skj_ref_case//11.par")
+read.MFCLPar("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 }

--- a/man/read.MFCLParBits.Rd
+++ b/man/read.MFCLParBits.Rd
@@ -7,17 +7,19 @@
 read.MFCLParBits(parfile, parobj = NULL, first.yr = 1972)
 }
 \arguments{
-\item{parfile:}{A character string giving the name and path of the frq file to be read}
+\item{parfile}{A character string giving the name and path of the frq file to be read.}
 
-\item{parobj:}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file}
+\item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 }
 \value{
-An object of class MFCLParBit
+An object of class MFCLParBit.
 }
 \description{
-Reads the remaining information from the par file and creates an MFCLParBits object
+Reads the remaining information from the par file and creates an MFCLParBits object.
 }
 \examples{
+\dontrun{
 read.MFCLParBits("C:/R4MFCL/test_data/skj_ref_case/11.par")
+}
 
 }

--- a/man/read.MFCLParBits.Rd
+++ b/man/read.MFCLParBits.Rd
@@ -18,6 +18,6 @@ An object of class MFCLParBit
 Reads the remaining information from the par file and creates an MFCLParBits object
 }
 \examples{
-read.MFCLParBits("C://R4MFCL//test_data//skj_ref_case//11.par")
+read.MFCLParBits("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 }

--- a/man/read.MFCLRec.Rd
+++ b/man/read.MFCLRec.Rd
@@ -20,6 +20,6 @@ An object of class MFCLRec
 Reads the recruitment information from the par file and creates an MFCLec object
 }
 \examples{
-read.MFCLRec("C://R4MFCL//test_data//skj_ref_case//11.par")
+read.MFCLRec("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 }

--- a/man/read.MFCLRec.Rd
+++ b/man/read.MFCLRec.Rd
@@ -7,19 +7,21 @@
 read.MFCLRec(parfile, parobj = NULL, first.yr = 1972)
 }
 \arguments{
-\item{parfile:}{A character string giving the name and path of the frq file to be read}
+\item{parfile}{A character string giving the name and path of the frq file to be read.}
 
-\item{parobj:}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file}
+\item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr:}{The first year of the input data time series (default value 1972)}
+\item{first.yr}{The first year of the input data time series (default value 1972).}
 }
 \value{
-An object of class MFCLRec
+An object of class MFCLRec.
 }
 \description{
-Reads the recruitment information from the par file and creates an MFCLec object
+Reads the recruitment information from the par file and creates an MFCLec object.
 }
 \examples{
+\dontrun{
 read.MFCLRec("C:/R4MFCL/test_data/skj_ref_case/11.par")
+}
 
 }

--- a/man/read.MFCLRegion.Rd
+++ b/man/read.MFCLRegion.Rd
@@ -20,6 +20,6 @@ An object of class MFCLRec
 Reads the region specific information from the par file and creates an MFCLRegion object
 }
 \examples{
-read.MFCLRegion("C://R4MFCL//test_data//skj_ref_case//11.par")
+read.MFCLRegion("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 }

--- a/man/read.MFCLRegion.Rd
+++ b/man/read.MFCLRegion.Rd
@@ -7,19 +7,21 @@
 read.MFCLRegion(parfile, parobj = NULL, first.yr = 1972)
 }
 \arguments{
-\item{parfile:}{A character string giving the name and path of the frq file to be read}
+\item{parfile}{A character string giving the name and path of the frq file to be read.}
 
-\item{parobj:}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file}
+\item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr:}{The first year of the input data time series (default value 1972)}
+\item{first.yr}{The first year of the input data time series (default value 1972).}
 }
 \value{
-An object of class MFCLRec
+An object of class MFCLRec.
 }
 \description{
-Reads the region specific information from the par file and creates an MFCLRegion object
+Reads the region specific information from the par file and creates an MFCLRegion object.
 }
 \examples{
+\dontrun{
 read.MFCLRegion("C:/R4MFCL/test_data/skj_ref_case/11.par")
+}
 
 }

--- a/man/read.MFCLRep.Rd
+++ b/man/read.MFCLRep.Rd
@@ -7,16 +7,18 @@
 read.MFCLRep(repfile)
 }
 \arguments{
-\item{inifile:}{A character string giving the name and path of the .rep file to be read}
+\item{inifile}{A character string giving the name and path of the .rep file to be read.}
 }
 \value{
 An object of class MFCLRep
 }
 \description{
-Reads information from the .rep file and creates an MFCLRep object
+Reads information from the .rep file and creates an MFCLRep object.
 }
 \examples{
-read.MFCLIni("C:/R4MFCL/test_data/skj_ref_case/plot-out.par.rep")
-read.MFCLIni("/home/roberts/skj/HCR/run0/plot-out.par.rep")
+\dontrun{
+read.MFCLRep("C:/R4MFCL/test_data/skj_ref_case/plot-out.par.rep")
+read.MFCLRep("/home/roberts/skj/HCR/run0/plot-out.par.rep")
+}
 
 }

--- a/man/read.MFCLRep.Rd
+++ b/man/read.MFCLRep.Rd
@@ -16,7 +16,7 @@ An object of class MFCLRep
 Reads information from the .rep file and creates an MFCLRep object
 }
 \examples{
-read.MFCLIni("C://R4MFCL//test_data//skj_ref_case//plot-out.par.rep")
+read.MFCLIni("C:/R4MFCL/test_data/skj_ref_case/plot-out.par.rep")
 read.MFCLIni("/home/roberts/skj/HCR/run0/plot-out.par.rep")
 
 }

--- a/man/read.MFCLSel.Rd
+++ b/man/read.MFCLSel.Rd
@@ -7,17 +7,19 @@
 read.MFCLSel(parfile, parobj = NULL, first.yr = 1972)
 }
 \arguments{
-\item{parfile:}{A character string giving the name and path of the frq file to be read}
+\item{parfile}{A character string giving the name and path of the frq file to be read.}
 
-\item{parobj:}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file}
+\item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 }
 \value{
-An object of class MFCLSel
+An object of class MFCLSel.
 }
 \description{
-Reads the Selection information from the par file and creates an MFCLSel object
+Reads the Selection information from the par file and creates an MFCLSel object.
 }
 \examples{
+\dontrun{
 read.MFCLSel("C:/R4MFCL/test_data/skj_ref_case/11.par")
+}
 
 }

--- a/man/read.MFCLSel.Rd
+++ b/man/read.MFCLSel.Rd
@@ -18,6 +18,6 @@ An object of class MFCLSel
 Reads the Selection information from the par file and creates an MFCLSel object
 }
 \examples{
-read.MFCLSel("C://R4MFCL//test_data//skj_ref_case//11.par")
+read.MFCLSel("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 }

--- a/man/read.MFCLTag.Rd
+++ b/man/read.MFCLTag.Rd
@@ -16,6 +16,6 @@ An object of class character vector
 Reads information from the tag file and creates  object
 }
 \examples{
-read.MFCLTag("C://R4MFCL//test_data//skj_ref_case//skj.tag")
+read.MFCLTag("C:/R4MFCL/test_data/skj_ref_case/skj.tag")
 
 }

--- a/man/read.MFCLTag.Rd
+++ b/man/read.MFCLTag.Rd
@@ -7,15 +7,17 @@
 read.MFCLTag(tagfile)
 }
 \arguments{
-\item{tagfile:}{A character string giving the name and path of the tag file to be read}
+\item{tagfile}{A character string giving the name and path of the tag file to be read.}
 }
 \value{
-An object of class character vector
+An object of class character vector.
 }
 \description{
-Reads information from the tag file and creates  object
+Reads information from the tag file and creates object.
 }
 \examples{
+\dontrun{
 read.MFCLTag("C:/R4MFCL/test_data/skj_ref_case/skj.tag")
+}
 
 }

--- a/man/read.MFCLTagRep.Rd
+++ b/man/read.MFCLTagRep.Rd
@@ -7,17 +7,19 @@
 read.MFCLTagRep(parfile, parobj = NULL, first.yr = 1972)
 }
 \arguments{
-\item{parfile:}{A character string giving the name and path of the frq file to be read}
+\item{parfile}{A character string giving the name and path of the frq file to be read.}
 
-\item{parobj:}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file}
+\item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 }
 \value{
-An object of class MFCLTagRep
+An object of class MFCLTagRep.
 }
 \description{
-Reads the TAaRep information from the par file and creates an MFCLTagRep object
+Reads the TAaRep information from the par file and creates an MFCLTagRep object.
 }
 \examples{
+\dontrun{
 read.MFCLTagRep("C:/R4MFCL/test_data/skj_ref_case/11.par")
+}
 
 }

--- a/man/read.MFCLTagRep.Rd
+++ b/man/read.MFCLTagRep.Rd
@@ -18,6 +18,6 @@ An object of class MFCLTagRep
 Reads the TAaRep information from the par file and creates an MFCLTagRep object
 }
 \examples{
-read.MFCLTagRep("C://R4MFCL//test_data//skj_ref_case//11.par")
+read.MFCLTagRep("C:/R4MFCL/test_data/skj_ref_case/11.par")
 
 }

--- a/man/recPeriod.Rd
+++ b/man/recPeriod.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/flagTools.r
 \name{recPeriod}
 \alias{recPeriod}
-\title{recruitment peiods}
+\title{recruitment periods}
 \usage{
 recPeriod(
   par,
@@ -14,7 +14,7 @@ recPeriod(
 )
 }
 \arguments{
-\item{parfile}{A object of class MFCLPar}
+\item{parfile}{An object of class MFCLPar}
 }
 \value{
 An object of class numeric vector
@@ -23,6 +23,7 @@ An object of class numeric vector
 Calculates recruitment periods for deterministic and stochastic projection settings
 }
 \examples{
+data(par)
 recPeriod(par)
 
 }

--- a/man/write-methods.Rd
+++ b/man/write-methods.Rd
@@ -47,7 +47,9 @@ Creates a text file at the specified location.
 Writes MFCL objects to a text file
 }
 \examples{
-write(MFCLFrqStats())
+\dontrun{
+write(MFCLFrqStats(), "file.txt")
+}
 }
 \seealso{
 \code{\link{read.MFCLFrq}} and \code{\link{read.MFCLPar}}


### PR DESCRIPTION
Hi,

This pull request fixes two things:

(1) **Installation warning**. Installing the package with install_github("PacificCommunity/FLR4MFCL") raises a warning:
```
WARNING: Added dependency on R >= 3.5.0 because serialized objects in
serialize/load version 3 cannot be read in older versions of R.
```
This is fixed with commit 59959c0 by adding dependency on R >= 3.5.0.

The FLR4MFCL package now installs without warnings.

(2) **R CMD check errors**. Checking the package with R CMD check raises an error, trying to run an example that produces an error. After fixing the error, R CMD check will raise another error, related to the next example. After sequential fixes, it turns out there were around 30 examples in the help pages that return an error if the user tries to run them. This pull request fixes some examples (so they actually run) and braces other examples inside a \dontrun{} clause, which is best practice when examples read or write files (even if files exist, such as system.file calls).

The FLR4MFCL package now clears R CMD check without errors.