### PR TITLE
Improve reporting of likelihoods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,4 +15,4 @@ License: GPL-3
 LazyData: No
 VignetteBuilder: knitr
 Encoding: UTF-8
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -550,6 +550,8 @@ exportMethods(
   "w_frq",
   "w_frq<-",
   "waa",
+  "weight_fish",
+  "weight_fish<-",
   "window",
   "write",
   "wtfrq",

--- a/R/AllClasses.R
+++ b/R/AllClasses.R
@@ -725,7 +725,7 @@ setValidity("MFCLTagProj", validMFCLTagProj)
 remove(validMFCLTagProj)
 #'MFCLTagProj
 #'
-#'Basic constructor for MFCLTag class
+#'Basic constructor for MFCLTagProj class
 #'@export
 MFCLTagProj <- function(ptd=NULL, reprate=NULL) {
   res <- new("MFCLTagProj")
@@ -913,9 +913,9 @@ setClass("MFCLprojControl",
 )
 setValidity("MFCLprojControl", validMFCLprojControl)
 remove(validMFCLprojControl)
-#'projControl
+#'MFCLprojControl
 #'
-#'Basic constructor for projControl class
+#'Basic constructor for MFCLprojControl class
 #'@export
 MFCLprojControl <- function(nyears=as.numeric(NULL), nsims=as.numeric(NULL), avyrs='', fprojyr=as.numeric(NULL), controls=data.frame(name=NULL, region=NULL, caeff=NULL, scaler=NULL, ess=NULL)) {
   
@@ -996,7 +996,7 @@ setValidity("MFCLLenFit", validMFCLLenFit)
 remove(validMFCLLenFit)
 #'MFCLLenFit
 #'
-#'Basic constructor for MFCLCatch class
+#'Basic constructor for MFCLLenFit class
 #'@export
 MFCLLenFit <- function() {return(new("MFCLLenFit"))}
 
@@ -1043,7 +1043,7 @@ setClass("MFCLLikelihood",
 )
 setValidity("MFCLLikelihood", validMFCLLikelihood)
 remove(validMFCLLikelihood)
-#'MFCLLenFit
+#'MFCLLikelihood
 #'
 #'Basic constructor for MFCLLikelihood class
 #'@export
@@ -1132,7 +1132,7 @@ setValidity("MFCLPseudoControl", validMFCLPseudoControl)
 remove(validMFCLPseudoControl)
 #'MFCLPseudoControl
 #'
-#'Basic constructor for MFCLPseudo class
+#'Basic constructor for MFCLPseudoControl class
 #'@export
 MFCLPseudoControl <- function(catch_sd=20, effort_sd=20, tag_fish_rep_rate=0.9, catch_seed=16001, effort_seed=17001, length_seed=18001, weight_seed=19001, tag_seed=20001) {
   
@@ -1166,7 +1166,7 @@ setValidity("MFCLEMControl", validMFCLEMControl)
 remove(validMFCLEMControl)
 #'MFCLEMControl
 #'
-#'Basic constructor for MFCLPseudo class
+#'Basic constructor for MFCLEMControl class
 #'@export
 MFCLEMControl <- function(doitall=function(){}, tag_fish_rep_rate=0.9,...) {
   

--- a/R/genericMethods.r
+++ b/R/genericMethods.r
@@ -158,13 +158,14 @@ setMethod("iter", signature(obj="MFCLPseudo"),
 setMethod("summary", signature(object="MFCLLikelihood"),
           function(object) {
             obj <- object
-            res <- data.frame(component=c("bhsteep","effort_dev","catchability_dev","length_comp","weight_comp","tag_data", "total"),
+            res <- data.frame(component=c("bhsteep","effort_dev","catchability_dev","length_comp","weight_comp","tag_data","cpue","total"),
                               likelihood=c(bh_steep_contrib(obj),
                                            sum(effort_dev_penalty(obj)),
                                            sum(q_dev_pen_fish_grp(obj)),
                                            sum(unlist(length_fish(obj))),
                                            sum(unlist(weight_fish(obj))),
                                            sum(unlist(tag_rel_fish(obj))),
+                                           sum(survey_index(obj), na.rm=TRUE),
                                            0))
             res$likelihood[res$component == "total"] <- sum(res$likelihood)
             return(res)

--- a/R/genericMethods.r
+++ b/R/genericMethods.r
@@ -166,7 +166,7 @@ setMethod("summary", signature(object="MFCLLikelihood"),
                                            sum(unlist(weight_fish(obj))),
                                            sum(unlist(tag_rel_fish(obj))),
                                            0))
-            res[7,"likelihood"] <- abs(sum(res[,"likelihood"]))
+            res$likelihood[res$component == "total"] <- sum(res$likelihood)
             return(res)
           }
 ) # }}}

--- a/man/MFCLEMControl.Rd
+++ b/man/MFCLEMControl.Rd
@@ -12,5 +12,5 @@ MFCLEMControl(
 )
 }
 \description{
-Basic constructor for MFCLPseudo class
+Basic constructor for MFCLEMControl class
 }

--- a/man/MFCLLenFit.Rd
+++ b/man/MFCLLenFit.Rd
@@ -7,5 +7,5 @@
 MFCLLenFit()
 }
 \description{
-Basic constructor for MFCLCatch class
+Basic constructor for MFCLLenFit class
 }

--- a/man/MFCLLikelihood.Rd
+++ b/man/MFCLLikelihood.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/AllClasses.R
 \name{MFCLLikelihood}
 \alias{MFCLLikelihood}
-\title{MFCLLenFit}
+\title{MFCLLikelihood}
 \usage{
 MFCLLikelihood()
 }

--- a/man/MFCLPseudoControl.Rd
+++ b/man/MFCLPseudoControl.Rd
@@ -16,5 +16,5 @@ MFCLPseudoControl(
 )
 }
 \description{
-Basic constructor for MFCLPseudo class
+Basic constructor for MFCLPseudoControl class
 }

--- a/man/MFCLTagProj.Rd
+++ b/man/MFCLTagProj.Rd
@@ -7,5 +7,5 @@
 MFCLTagProj(ptd = NULL, reprate = NULL)
 }
 \description{
-Basic constructor for MFCLTag class
+Basic constructor for MFCLTagProj class
 }

--- a/man/MFCLprojControl.Rd
+++ b/man/MFCLprojControl.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/AllClasses.R
 \name{MFCLprojControl}
 \alias{MFCLprojControl}
-\title{projControl}
+\title{MFCLprojControl}
 \usage{
 MFCLprojControl(
   nyears = as.numeric(NULL),
@@ -14,5 +14,5 @@ MFCLprojControl(
 )
 }
 \description{
-Basic constructor for projControl class
+Basic constructor for MFCLprojControl class
 }

--- a/man/read.MFCLPseudo.Rd
+++ b/man/read.MFCLPseudo.Rd
@@ -10,7 +10,8 @@ read.MFCLPseudo(
   lw_sim = "missing",
   projfrq = "missing",
   ctrl = "missing",
-  historical = TRUE
+  historical = TRUE,
+  ii = 1
 )
 }
 \arguments{
@@ -18,16 +19,15 @@ read.MFCLPseudo(
 
 \item{effort}{A character string giving the name and path of the effort.sim file to be read.}
 
-\item{lw_sim}{A character string giving the name and path of the lw_sim file to be read.}
+\item{lw_sim}{A character string giving the name and path of the test_lw_sim (or test_lw_sim_alt) file to be read.}
 
-\item{projfrq}{undocumented.}
+\item{projfrq}{The projection *.frq object from which the pseudo data were generated.}
 
-\item{ctrl}{undocumented.}
+\item{ctrl}{The corresponding projection control object.}
 }
 \value{
 An object of class MFCLPseudo
 }
 \description{
 Reads information from the pseudo generation files and creates an MFCLPseudo object.
-This method is a complicated mess and really needs to be simplified.
 }

--- a/man/read.MFCLPseudoSizeComp.Rd
+++ b/man/read.MFCLPseudoSizeComp.Rd
@@ -5,7 +5,7 @@
 \title{Read MFCLPseudo Size Comp}
 \usage{
 read.MFCLPseudoSizeComp(
-  lw_sim = "test_lw_sim",
+  lw_sim = "test_lw_sim_alt",
   projfrq = projfrq,
   ctrl = "missing",
   historical = FALSE
@@ -24,7 +24,7 @@ read.MFCLPseudoSizeComp(
 An object of class \linkS4class{MFCLPseudo}.
 }
 \description{
-Reads in simulated length and weight size composition data from the MFCL generated file 'test_lw_sim' and
+Reads in simulated length and weight size composition data from the MFCL generated file 'test_lw_sim' (or 'test_lw_sim_alt') and
 returns a partially complete object of MFCLPseudo. The 'catcheff' slot of the MFCLPseudo object is not filled.
 }
 \details{


### PR DESCRIPTION
Hi! This pull request improve summary(MFCLLikelihood) by:

1. Reporting the neglogL instead of abs(neglogL)
2. Including the CPUE (survey_index) likelihood, a key component of this year's assessments

Also included are some minor improvements to the package in general:

1. Export the weight_fish() method, in the same way as length_fish() is exported
2. Constructor help pages now have the correct class names shown