### PR TITLE
Use Authors@R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,9 @@ Package: FLR4MFCL
 Version: 1.6.6
 Date: 2023-05-25
 Title: R Functions for Taming MULTIFAN-CL
-Author: c(person("Robert", "Scott", role=c("aut","cre"), email="robertsc@spc.int"),
+Authors@R: c(person("Robert", "Scott", role=c("aut","cre"), email="robertsc@spc.int"),
              person("Finlay", "Scott", role="aut"),
              person("Arni", "Magnusson", role="aut"))
-Maintainer: Robert Scott <robertsc@spc.int>
 Depends: R (>= 3.5.0), lattice, FLCore
 Imports: methods, utils
 Suggests: mapdata, knitr, rmarkdown


### PR DESCRIPTION
I suggest we (continue to) use the modern `Authors@R` entry instead of the classic `Author` and `Maintainer` entries, which can be omitted.

The main benefit of using 'Authors@R' is that it allows us to distinguish between coauthors (of functions) and contributors (of other stuff). We don't have contributors yet, but the door is open :)

The state before this pull request is that if one types `citation("FLR4MFCL")` in an R session, the author entry is broken.