### PR TITLE
Document new behavior of first.yr

### DIFF
--- a/R/read.MFCLPar.r
+++ b/R/read.MFCLPar.r
@@ -721,6 +721,15 @@ read.MFCLParBits <- function(parfile, parobj=NULL, first.yr=NA) {
 #' @param parfile A character string giving the name and path of the frq file to be read.
 #' @param first.yr The first year of the input data time series (default value NA).
 #'
+#' @details
+#' The \code{first.yr} argument is ignored when reading par files from MFCL
+#' version 2.2.2.0 (2023-07-07) and later, since the correct first year is now
+#' embedded in the par file.
+#'
+#' For older par files that do not contain the first year, the user is required
+#' to pass an appropriate value as \code{first.yr}. The \code{\link{firstYear}}
+#' function can be helpful when working with old model runs.
+#'
 #' @return An object of class \code{MFCLPar}.
 #'
 #' @seealso
@@ -728,7 +737,8 @@ read.MFCLParBits <- function(parfile, parobj=NULL, first.yr=NA) {
 #'
 #' @examples
 #' \dontrun{
-#' read.MFCLPar("C:/R4MFCL/test_data/skj_ref_case/11.par")
+#' read.MFCLPar("yft/2020/11.par", first.yr=1952)  # old MFCL, must specify year
+#' read.MFCLPar("yft/2023/11.par")                 # new MFCL, automatic year
 #' }
 #'
 #' @export

--- a/man/read.MFCLBiol.Rd
+++ b/man/read.MFCLBiol.Rd
@@ -4,14 +4,14 @@
 \alias{read.MFCLBiol}
 \title{read.MFCLBiol}
 \usage{
-read.MFCLBiol(parfile, parobj = NULL, first.yr = 1972)
+read.MFCLBiol(parfile, parobj = NULL, first.yr = NA)
 }
 \arguments{
 \item{parfile}{A character string giving the name and path of the frq file to be read.}
 
 \item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr}{The first year of the input data time series (default value 1972).}
+\item{first.yr}{The first year of the input data time series (default value NA).}
 }
 \value{
 An object of class MFCLBiol.

--- a/man/read.MFCLFlags.Rd
+++ b/man/read.MFCLFlags.Rd
@@ -4,14 +4,14 @@
 \alias{read.MFCLFlags}
 \title{read.MFCLFlags}
 \usage{
-read.MFCLFlags(parfile, parobj = NULL, first.yr = 1972)
+read.MFCLFlags(parfile, parobj = NULL, first.yr = NA)
 }
 \arguments{
 \item{parfile}{A character string giving the name and path of the frq file to be read.}
 
 \item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr}{The first year of the input data time series (default value 1972).}
+\item{first.yr}{The first year of the input data time series (default value NA).}
 }
 \value{
 An object of class MFCLFlags.

--- a/man/read.MFCLPar.Rd
+++ b/man/read.MFCLPar.Rd
@@ -4,12 +4,12 @@
 \alias{read.MFCLPar}
 \title{read.MFCLPar}
 \usage{
-read.MFCLPar(parfile, first.yr = 1972)
+read.MFCLPar(parfile, first.yr = NA)
 }
 \arguments{
 \item{parfile}{A character string giving the name and path of the frq file to be read.}
 
-\item{first.yr}{The first year of the input data time series (default value 1972).}
+\item{first.yr}{The first year of the input data time series (default value NA).}
 }
 \value{
 An object of class \code{MFCLPar}.

--- a/man/read.MFCLPar.Rd
+++ b/man/read.MFCLPar.Rd
@@ -17,9 +17,19 @@ An object of class \code{MFCLPar}.
 \description{
 Read information from the par file.
 }
+\details{
+The \code{first.yr} argument is ignored when reading par files from MFCL
+version 2.2.2.0 (2023-07-07) and later, since the correct first year is now
+embedded in the par file.
+
+For older par files that do not contain the first year, the user is required
+to pass an appropriate value as \code{first.yr}. The \code{\link{firstYear}}
+function can be helpful when working with old model runs.
+}
 \examples{
 \dontrun{
-read.MFCLPar("C:/R4MFCL/test_data/skj_ref_case/11.par")
+read.MFCLPar("yft/2020/11.par", first.yr=1952)  # old MFCL, must specify year
+read.MFCLPar("yft/2023/11.par")                 # new MFCL, automatic year
 }
 
 }

--- a/man/read.MFCLParBits.Rd
+++ b/man/read.MFCLParBits.Rd
@@ -4,14 +4,14 @@
 \alias{read.MFCLParBits}
 \title{read.MFCLParBits}
 \usage{
-read.MFCLParBits(parfile, parobj = NULL, first.yr = 1972)
+read.MFCLParBits(parfile, parobj = NULL, first.yr = NA)
 }
 \arguments{
 \item{parfile}{A character string giving the name and path of the frq file to be read.}
 
 \item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr}{The first year of the input data time series (default value 1972).}
+\item{first.yr}{The first year of the input data time series (default value NA).}
 }
 \value{
 An object of class MFCLParBit.

--- a/man/read.MFCLRec.Rd
+++ b/man/read.MFCLRec.Rd
@@ -4,14 +4,14 @@
 \alias{read.MFCLRec}
 \title{read.MFCLRec}
 \usage{
-read.MFCLRec(parfile, parobj = NULL, first.yr = 1972)
+read.MFCLRec(parfile, parobj = NULL, first.yr = NA)
 }
 \arguments{
 \item{parfile}{A character string giving the name and path of the frq file to be read.}
 
 \item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr}{The first year of the input data time series (default value 1972).}
+\item{first.yr}{The first year of the input data time series (default value NA).}
 }
 \value{
 An object of class MFCLRec.

--- a/man/read.MFCLRegion.Rd
+++ b/man/read.MFCLRegion.Rd
@@ -4,14 +4,14 @@
 \alias{read.MFCLRegion}
 \title{read.MFCLRegion}
 \usage{
-read.MFCLRegion(parfile, parobj = NULL, first.yr = 1972)
+read.MFCLRegion(parfile, parobj = NULL, first.yr = NA)
 }
 \arguments{
 \item{parfile}{A character string giving the name and path of the frq file to be read.}
 
 \item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr}{The first year of the input data time series (default value 1972).}
+\item{first.yr}{The first year of the input data time series (default value NA).}
 }
 \value{
 An object of class MFCLRec.

--- a/man/read.MFCLSel.Rd
+++ b/man/read.MFCLSel.Rd
@@ -4,14 +4,14 @@
 \alias{read.MFCLSel}
 \title{read.MFCLSel}
 \usage{
-read.MFCLSel(parfile, parobj = NULL, first.yr = 1972)
+read.MFCLSel(parfile, parobj = NULL, first.yr = NA)
 }
 \arguments{
 \item{parfile}{A character string giving the name and path of the frq file to be read.}
 
 \item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr}{The first year of the input data time series (default value 1972).}
+\item{first.yr}{The first year of the input data time series (default value NA).}
 }
 \value{
 An object of class MFCLSel.

--- a/man/read.MFCLTagRep.Rd
+++ b/man/read.MFCLTagRep.Rd
@@ -4,14 +4,14 @@
 \alias{read.MFCLTagRep}
 \title{read.MFCLTagRep}
 \usage{
-read.MFCLTagRep(parfile, parobj = NULL, first.yr = 1972)
+read.MFCLTagRep(parfile, parobj = NULL, first.yr = NA)
 }
 \arguments{
 \item{parfile}{A character string giving the name and path of the frq file to be read.}
 
 \item{parobj}{A character string containing the par file. If parobj is NULL the function uses parfile to read in the par file.}
 
-\item{first.yr}{The first year of the input data time series (default value 1972).}
+\item{first.yr}{The first year of the input data time series (default value NA).}
 }
 \value{
 An object of class MFCLTagRep.


### PR DESCRIPTION
That's a great improvement in MFCL and now FLR4MFCL, that the user can import a par file without the default value of first.yr=1972 which was creating problems for BET and YFT analyses.

This pull request documents the new behavior when working with old or new MFCL files.